### PR TITLE
Improve support for splitted packages when DEVELSRCDIR is set.

### DIFF
--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -148,7 +148,7 @@ check_devel() {
 		|| [[ -n "${_darcsmod}" && -n "${_darcstrunk}" ]] \
 		|| [[ -n "${_bzrtrunk}" && -n "${_bzrmod}" ]] \
 		|| [[ -n "${_gitroot}" && -n "${_gitname}" ]] \
-		|| [[ $pkgname =~ -(bzr|git|hg|svn)$ ]]; then
+		|| [[ ${pkgname[0]} =~ -(bzr|git|hg|svn)$ ]]; then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
An example is 'linux-git', which is the Linux kernel source on AUR.
This is a splitted package, which contains a large git clone. It would
be nice if it doesn't have to be downloaded completely each time,
which is the essence of the DEVELSRCDIR (DEVELBUILDDIR) option.

This patch assumes that the correct pkgname name is in the first
element of the array. If pkgname is not an array, the normal
pkgname will be used, which was the behaviour before this patch.
