### PR TITLE
No need to list or run namcap on debugging symbol packages.

### DIFF
--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -273,13 +273,13 @@ install_package() {
 		echo
 		case "$answer" in
 			V)	local i=0
-				for _file in "$YPKGDEST"/!(*.sig); do
+				for _file in "$YPKGDEST"/!(*.sig|*-debug-*); do
 					(( i++ )) && { prompt2 $(gettext 'Press any key to continue'); read -n 1; }
 					$PACMAN -Qlp "$_file"
 				done
 				;;
 			C)	if type -p namcap &>/dev/null ; then
-					for _file in "$YPKGDEST"/!(*.sig); do
+					for _file in "$YPKGDEST"/!(*.sig|*-debug-*); do
 						namcap "$_file"
 					done
 				else


### PR DESCRIPTION
Pacman 4.1 added the ability to split out debugging symbols into a separate package. This just tells yaourt to ignore them when viewing file list or running namcap.
