### PR TITLE
Show the date of the latest update instead of the first submission. Use the same date format as for comments.

### DIFF
--- a/src/lib/aur.sh
+++ b/src/lib/aur.sh
@@ -153,7 +153,7 @@ vote_package() {
 # give to user all info to build and install Unsupported package from AUR
 install_from_aur() {
 	local cwd
-	declare -a pkginfo=($(pkgquery -1Aif "%n %i %v %w %o %u %m %l %S" "$1"))
+	declare -a pkginfo=($(pkgquery -1Aif "%n %i %v %w %o %u %m %l %L" "$1"))
 	[[ "${pkginfo[1]#-}" ]] || return 1
 	title $(_gettext 'Installing %s from AUR' "${pkginfo[0]}")
 	cwd=$(pwd)
@@ -163,7 +163,7 @@ install_from_aur() {
 	aur_get_pkgbuild "${pkginfo[0]}" "${pkginfo[5]}" ||
 	  { cd "$cwd"; return 1; }
 	aur_comments ${pkginfo[0]}
-	echo -e "$CBOLD${pkginfo[0]} ${pkginfo[2]} $C0 ($(date -d "@${pkginfo[8]}"))"
+	echo -e "$CBOLD${pkginfo[0]} ${pkginfo[2]} $C0 ($(date -u -d "@${pkginfo[8]}" "+%F %H-%M"))"
 	[[ ! ${pkginfo[6]#-} ]] && echo -e "$CBLINK$CRED$(gettext 'This package is orphaned')$C0"
 	echo -e "$CBLINK$CRED$(gettext '( Unsupported package: Potentially dangerous ! )')$C0"
 


### PR DESCRIPTION
Currently yaourt shows the date of the first submission to the AUR. Example:

```
Comment by josephgbr  (2014-06-23 11:30)
@tuxce: please update. This PKGBUILD is out-of-date, in comparison with archlinuxfr..

package-query 1.4-1  (Thu Mar 25 00:18:00 CET 2010)
( Unsupported package: Potentially dangerous ! )
```

It would be much more useful to show the date of the latest update so that you can compare the dates of the comments to see if they are still relevant. Example:

```
Comment by josephgbr  (2014-06-23 11:30)
@tuxce: please update. This PKGBUILD is out-of-date, in comparison with archlinuxfr..

package-query 1.4-1  (Mon Jun 23 13:37:50 CEST 2014)
( Unsupported package: Potentially dangerous ! )
```

Even nicer: change the date format to be the same as for the comments:

```
Comment by josephgbr  (2014-06-23 11:30)
@tuxce: please update. This PKGBUILD is out-of-date, in comparison with archlinuxfr..

package-query 1.4-1  (2014-06-23 11:37)
( Unsupported package: Potentially dangerous ! )
```
