### PR TITLE
removed dangerous --sucre option

### DIFF
--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -336,9 +336,6 @@ while [[ $1 ]]; do
 		--rsort)            RSORT=$2; shift;;
 		--sort)             SORT=$2; shift;;
 		--stats)            MAJOR="stats";;
-		--sucre)            MAJOR="sync"
-			FORCE=1; SYSUPGRADE=1; REFRESH=2;
-			AURUPGRADE=1; DEVEL=1; NOCONFIRM=2;;
 		--tmp)              shift; TMPDIR="$1";;
 		-V|--version)       version; exit 0;;
 		-v)                 program_arg $((A_PQ | A_PS)) $1;;


### PR DESCRIPTION
This commit removes the --sucre option, which is ludicrously dangerous. According to the documentation, it should be used "only on compromised system", or in other words "already broken system". It is however widely used by users for "convenience" sake.

Please stop the bleeding and get rid of this option.
