### PR TITLE
Improve parsing of multiline array in sanitize_pkgbuild()

### DIFF
--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -374,9 +374,8 @@ sanitize_pkgbuild() {
 	sed -n -e '/\$(\|`\|[><](\|[&|]\|;/d' -e '/ *[a-zA-Z0-9_\-]\+ *( *)/q' -e 's/^ *[a-zA-Z0-9_]\+=/declare &/' -e 'p' "$file" > "$tmpfile"
 	sed -n -e '1,/^\r$/ { s/Last-Modified: \(.*\)\r/declare last_mod="\1"/p;d }' \
 	       -e '/^declare *[a-zA-Z0-9_]\+=(.*) *\(#.*\|$\)/{p;d}' \
+	       -e '/^declare *[a-zA-Z0-9_]\+=(.*$/ {:a;N;$bb;/.*) *\(#.*\|$\)/!ba;s/\n/ /g;p;d;:b}' \
 	       -e '/^declare *[a-zA-Z0-9_]\+=.*[^\\]$/{p;d}' "$tmpfile"
-	sed -n -e '/^declare *[a-zA-Z0-9_]\+=(.*) *\(#.*\|$\)/d' \
-	       -e '/^declare *[a-zA-Z0-9_]\+=(.*$/ {:a;N;$bb;/.*) *\(#.*\|$\)/!ba;s/\n/ /g;p;d;:b}' "$tmpfile"
 	sed -n -e '/^declare *[a-zA-Z0-9_]\+=.*\\$/ {:a;N;$bb;/.*[^\\]$/!ba;s/\n/ /g;p;d;:b}' "$tmpfile"
 	rm "$tmpfile"
 }


### PR DESCRIPTION
Change sed expressions order in order to avoid printing the first line
of a multiline array twice.

Fix #58