### PR TITLE
Sort packages in sysupgrade prompt

### DIFF
--- a/src/lib/abs.sh.in
+++ b/src/lib/abs.sh.in
@@ -241,6 +241,7 @@ sysupgrade() {
 	fi
 	#[[ ! "$packages" ]] && return 0
 	local cmd="echo -n"
+	readarray -t packages < <(for a in "${packages[@]}"; do echo "$a"; done | sort)
 	[[ $packages ]] && cmd+='; pkgquery -1Sif "%n %r %v %l - - %d" "${packages[@]}"'
 	if ((AURUPGRADE)); then
 		# TODO: %m return the maintainer for AUR package and packager for local packages.


### PR DESCRIPTION
Before:
```
==> Software upgrade (new version) :
core/kmod                                19-1             -> 20-1
core/libtasn1                            4.2-1            -> 4.3-1
core/curl                                7.40.0-1         -> 7.41.0-1
core/iproute2                            3.18.0-1         -> 3.19.0-1
core/logrotate                           3.8.8-2          -> 3.8.9-1
core/pacman-mirrorlist                   20150228-1       -> 20150315-1
core/patch                               2.7.4-1          -> 2.7.5-1
extra/libxfont                           1.5.0-1          -> 1.5.1-1
extra/xorg-font-util                     1.3.0-2          -> 1.3.1-1
extra/attica-qt5                         5.7.0-1          -> 5.8.0-1
extra/bluez                              5.28-1           -> 5.29-1
extra/bluez-libs                         5.28-1           -> 5.29-1
extra/bluez-utils                        5.28-1           -> 5.29-1
extra/llvm-libs                          3.5.1-1          -> 3.6.0-3
extra/mesa                               10.4.6-1         -> 10.5.1-2
extra/cairo                              1.14.0-2         -> 1.14.2-1
extra/randrproto                         1.4.0-2          -> 1.4.1-1
extra/gsfonts                            20130917-1       -> 20150122-1
extra/python2-setuptools                 1:14.0-1         -> 1:14.3-1
extra/clang                              3.5.1-1          -> 3.6.0-3
extra/cmake                              3.1.3-1          -> 3.2.1-1
extra/libxfce4ui                         4.12.0-1         -> 4.12.1-1
extra/exo                                0.10.3-2         -> 0.10.4-1
extra/libvdpau                           0.9-1            -> 1.1-1
extra/libx264                            2:142.20140826-1 -> 2:144.20150223-1
extra/ffmpeg                             1:2.6-2          -> 1:2.6.1-1
extra/flashplugin                        11.2.202.442-1   -> 11.2.202.451-1
extra/karchive                           5.7.0-1          -> 5.8.0-1
extra/kcoreaddons                        5.7.0-1          -> 5.8.0-1
extra/kauth                              5.7.0-1          -> 5.8.0-1
extra/kconfig                            5.7.0-1          -> 5.8.0-1
extra/kwindowsystem                      5.7.0-1          -> 5.8.0-1
extra/kcrash                             5.7.0-1          -> 5.8.0-1
extra/kdbusaddons                        5.7.0-1          -> 5.8.0-1
extra/ki18n                              5.7.0-1          -> 5.8.0-1
extra/kglobalaccel                       5.7.0-1          -> 5.8.0-1
extra/kwidgetsaddons                     5.7.0-1          -> 5.8.0-1
extra/kcompletion                        5.7.0-1          -> 5.8.0-1
extra/kservice                           5.7.0-1          -> 5.8.0-1
extra/kcodecs                            5.7.0-1          -> 5.8.0-1
extra/kguiaddons                         5.7.0-1          -> 5.8.0-1
extra/kconfigwidgets                     5.7.0-1          -> 5.8.0-1
extra/kitemviews                         5.7.0-1          -> 5.8.0-1
extra/kiconthemes                        5.7.0-2          -> 5.8.0-1
extra/sonnet                             5.7.0-1          -> 5.8.0-1
extra/ktextwidgets                       5.7.0-1          -> 5.8.0-1
extra/kxmlgui                            5.7.0-1          -> 5.8.0-1
extra/kbookmarks                         5.7.0-1          -> 5.8.0-1
extra/solid                              5.7.0-1          -> 5.8.0-1
extra/kjobwidgets                        5.7.0-1          -> 5.8.0-1
extra/knotifications                     5.7.0-1          -> 5.8.0-1
extra/kwallet                            5.7.0-1          -> 5.8.0-1
extra/kio                                5.7.0-1          -> 5.8.0-1
extra/kinit                              5.7.0-1          -> 5.8.0-1
extra/kded                               5.7.0-1          -> 5.8.0-1
extra/kunitconversion                    5.7.0-1          -> 5.8.0-1
extra/kplotting                          5.7.0-1          -> 5.8.0-1
extra/kparts                             5.7.0-1          -> 5.8.0-1
extra/kdewebkit                          5.7.0-1          -> 5.8.0-1
extra/kdesignerplugin                    5.7.0-1          -> 5.8.0-1
extra/kitemmodels                        5.7.0-1          -> 5.8.0-1
extra/kemoticons                         5.7.0-1          -> 5.8.0-1
extra/kdelibs4support                    5.7.0-1          -> 5.8.0-1
extra/knewstuff                          5.7.0-1          -> 5.8.0-1
extra/knotifyconfig                      5.7.0-1          -> 5.8.0-1
extra/kpty                               5.7.0-1          -> 5.8.0-1
extra/ktexteditor                        5.7.0-2          -> 5.8.0-1
extra/libxvmc                            1.0.8-1          -> 1.0.9-1
extra/llvm                               3.5.1-1          -> 3.6.0-3
extra/m17n-db                            1.6.5-2          -> 1.7.0-1
extra/m17n-lib                           1.6.4-2          -> 1.7.0-1
extra/postgresql-libs                    9.3.5-1          -> 9.4.1-1
extra/postgresql                         9.3.5-1          -> 9.4.1-1
extra/postgresql-docs                    9.3.5-1          -> 9.4.1-1
extra/postgresql-old-upgrade             9.2.9-1          -> 9.3.6-1
extra/python-setuptools                  1:14.0-1         -> 1:14.3-1
extra/threadweaver                       5.7.0-1          -> 5.8.0-1
extra/xfce4-session                      4.12.0-2         -> 4.12.1-1
community/cairo-dock                     3.4.0-1          -> 3.4.1-1
community/python2-apsw                   3.8.8.1-1        -> 3.8.8.2-1
community/calibre                        2.20.0-2         -> 2.21.0-1
community/libmatekbd                     1.8.0-1          -> 1.8.1-1
community/mate-desktop                   1.8.1-2          -> 1.8.2-1
community/marco                          1.8.2-4          -> 1.8.3-1
community/mate-settings-daemon-gstreamer 1.8.2-3          -> 1.8.3-1
community/maven                          3.2.5-1          -> 3.3.1-1
community/mpv                            0.8.2-2          -> 0.8.3-1
community/python-html2text               2014.12.29-2     -> 2015.2.18-1
community/virtualbox-host-modules        4.3.24-1         -> 4.3.26-1
community/virtualbox                     4.3.24-1         -> 4.3.26-1
community/virtualbox-guest-iso           4.3.24-1         -> 4.3.26-1
multilib/lib32-alsa-lib                  1.0.28-1         -> 1.0.29-1
multilib/lib32-glib2                     2.42.1-1         -> 2.42.2-1
multilib/lib32-libx11                    1.6.2-1          -> 1.6.3-1
multilib/lib32-libxxf86vm                1.1.3-1          -> 1.1.4-1
multilib/lib32-llvm-libs                 3.5.1-1          -> 3.6.0-1
multilib/lib32-libgcrypt                 1.6.2-1          -> 1.6.3-1
multilib/lib32-xz                        5.2.0-1          -> 5.2.1-1
multilib/lib32-libidn                    1.29-1           -> 1.30-1
multilib/lib32-mesa                      10.4.6-1         -> 10.5.1-1
multilib/lib32-cairo                     1.14.0-1         -> 1.14.2-1
multilib/lib32-gdk-pixbuf2               2.31.2-1         -> 2.31.3-1
multilib/lib32-gnutls                    3.3.12-1         -> 3.3.13-1

==> New package :
extra/jsoncpp                            1.4.4-1          (required by cmake)
```

After:
```
==> Software upgrade (new version) :
core/curl                                7.40.0-1         -> 7.41.0-1
core/iproute2                            3.18.0-1         -> 3.19.0-1
core/kmod                                19-1             -> 20-1
core/libtasn1                            4.2-1            -> 4.3-1
core/logrotate                           3.8.8-2          -> 3.8.9-1
core/pacman-mirrorlist                   20150228-1       -> 20150315-1
core/patch                               2.7.4-1          -> 2.7.5-1
extra/attica-qt5                         5.7.0-1          -> 5.8.0-1
extra/bluez                              5.28-1           -> 5.29-1
extra/bluez-libs                         5.28-1           -> 5.29-1
extra/bluez-utils                        5.28-1           -> 5.29-1
extra/cairo                              1.14.0-2         -> 1.14.2-1
extra/clang                              3.5.1-1          -> 3.6.0-3
extra/cmake                              3.1.3-1          -> 3.2.1-1
extra/exo                                0.10.3-2         -> 0.10.4-1
extra/ffmpeg                             1:2.6-2          -> 1:2.6.1-1
extra/flashplugin                        11.2.202.442-1   -> 11.2.202.451-1
extra/gsfonts                            20130917-1       -> 20150122-1
extra/karchive                           5.7.0-1          -> 5.8.0-1
extra/kauth                              5.7.0-1          -> 5.8.0-1
extra/kbookmarks                         5.7.0-1          -> 5.8.0-1
extra/kcodecs                            5.7.0-1          -> 5.8.0-1
extra/kcompletion                        5.7.0-1          -> 5.8.0-1
extra/kconfig                            5.7.0-1          -> 5.8.0-1
extra/kconfigwidgets                     5.7.0-1          -> 5.8.0-1
extra/kcoreaddons                        5.7.0-1          -> 5.8.0-1
extra/kcrash                             5.7.0-1          -> 5.8.0-1
extra/kdbusaddons                        5.7.0-1          -> 5.8.0-1
extra/kded                               5.7.0-1          -> 5.8.0-1
extra/kdelibs4support                    5.7.0-1          -> 5.8.0-1
extra/kdesignerplugin                    5.7.0-1          -> 5.8.0-1
extra/kdewebkit                          5.7.0-1          -> 5.8.0-1
extra/kemoticons                         5.7.0-1          -> 5.8.0-1
extra/kglobalaccel                       5.7.0-1          -> 5.8.0-1
extra/kguiaddons                         5.7.0-1          -> 5.8.0-1
extra/ki18n                              5.7.0-1          -> 5.8.0-1
extra/kiconthemes                        5.7.0-2          -> 5.8.0-1
extra/kinit                              5.7.0-1          -> 5.8.0-1
extra/kio                                5.7.0-1          -> 5.8.0-1
extra/kitemmodels                        5.7.0-1          -> 5.8.0-1
extra/kitemviews                         5.7.0-1          -> 5.8.0-1
extra/kjobwidgets                        5.7.0-1          -> 5.8.0-1
extra/knewstuff                          5.7.0-1          -> 5.8.0-1
extra/knotifications                     5.7.0-1          -> 5.8.0-1
extra/knotifyconfig                      5.7.0-1          -> 5.8.0-1
extra/kparts                             5.7.0-1          -> 5.8.0-1
extra/kplotting                          5.7.0-1          -> 5.8.0-1
extra/kpty                               5.7.0-1          -> 5.8.0-1
extra/kservice                           5.7.0-1          -> 5.8.0-1
extra/ktexteditor                        5.7.0-2          -> 5.8.0-1
extra/ktextwidgets                       5.7.0-1          -> 5.8.0-1
extra/kunitconversion                    5.7.0-1          -> 5.8.0-1
extra/kwallet                            5.7.0-1          -> 5.8.0-1
extra/kwidgetsaddons                     5.7.0-1          -> 5.8.0-1
extra/kwindowsystem                      5.7.0-1          -> 5.8.0-1
extra/kxmlgui                            5.7.0-1          -> 5.8.0-1
extra/libvdpau                           0.9-1            -> 1.1-1
extra/libx264                            2:142.20140826-1 -> 2:144.20150223-1
extra/libxfce4ui                         4.12.0-1         -> 4.12.1-1
extra/libxfont                           1.5.0-1          -> 1.5.1-1
extra/libxvmc                            1.0.8-1          -> 1.0.9-1
extra/llvm                               3.5.1-1          -> 3.6.0-3
extra/llvm-libs                          3.5.1-1          -> 3.6.0-3
extra/m17n-db                            1.6.5-2          -> 1.7.0-1
extra/m17n-lib                           1.6.4-2          -> 1.7.0-1
extra/mesa                               10.4.6-1         -> 10.5.1-2
extra/postgresql                         9.3.5-1          -> 9.4.1-1
extra/postgresql-docs                    9.3.5-1          -> 9.4.1-1
extra/postgresql-libs                    9.3.5-1          -> 9.4.1-1
extra/postgresql-old-upgrade             9.2.9-1          -> 9.3.6-1
extra/python2-setuptools                 1:14.0-1         -> 1:14.3-1
extra/python-setuptools                  1:14.0-1         -> 1:14.3-1
extra/randrproto                         1.4.0-2          -> 1.4.1-1
extra/solid                              5.7.0-1          -> 5.8.0-1
extra/sonnet                             5.7.0-1          -> 5.8.0-1
extra/threadweaver                       5.7.0-1          -> 5.8.0-1
extra/xfce4-session                      4.12.0-2         -> 4.12.1-1
extra/xorg-font-util                     1.3.0-2          -> 1.3.1-1
community/cairo-dock                     3.4.0-1          -> 3.4.1-1
community/calibre                        2.20.0-2         -> 2.21.0-1
community/libmatekbd                     1.8.0-1          -> 1.8.1-1
community/marco                          1.8.2-4          -> 1.8.3-1
community/mate-desktop                   1.8.1-2          -> 1.8.2-1
community/mate-settings-daemon-gstreamer 1.8.2-3          -> 1.8.3-1
community/maven                          3.2.5-1          -> 3.3.1-1
community/mpv                            0.8.2-2          -> 0.8.3-1
community/python2-apsw                   3.8.8.1-1        -> 3.8.8.2-1
community/python-html2text               2014.12.29-2     -> 2015.2.18-1
community/virtualbox                     4.3.24-1         -> 4.3.26-1
community/virtualbox-guest-iso           4.3.24-1         -> 4.3.26-1
community/virtualbox-host-modules        4.3.24-1         -> 4.3.26-1
multilib/lib32-alsa-lib                  1.0.28-1         -> 1.0.29-1
multilib/lib32-cairo                     1.14.0-1         -> 1.14.2-1
multilib/lib32-gdk-pixbuf2               2.31.2-1         -> 2.31.3-1
multilib/lib32-glib2                     2.42.1-1         -> 2.42.2-1
multilib/lib32-gnutls                    3.3.12-1         -> 3.3.13-1
multilib/lib32-libgcrypt                 1.6.2-1          -> 1.6.3-1
multilib/lib32-libidn                    1.29-1           -> 1.30-1
multilib/lib32-libx11                    1.6.2-1          -> 1.6.3-1
multilib/lib32-libxxf86vm                1.1.3-1          -> 1.1.4-1
multilib/lib32-llvm-libs                 3.5.1-1          -> 3.6.0-1
multilib/lib32-mesa                      10.4.6-1         -> 10.5.1-1
multilib/lib32-xz                        5.2.0-1          -> 5.2.1-1

==> New package :
extra/jsoncpp                            1.4.4-1          (required by cmake)
```