### PR TITLE
Feature: Ignore packages

### DIFF
--- a/src/lib/abs.sh.in
+++ b/src/lib/abs.sh.in
@@ -129,6 +129,10 @@ classify_pkg() {
 		((REFRESH)) && printf -vprefix "\r " || printf -vprefix "\r"
 	fi
 	while read pkgname repo rversion lversion outofdate maintainer pkgdesc; do
+		if [[ "${IGNORED_PACKAGES[@]}" =~ "$repo/$pkgname" ]]; then
+			continue;
+		fi
+		
 		printf -v pkgdesc "%q" "$pkgdesc"
 		if [[ "$repo" = "aur" && ${lversion#-} ]] || [[ "$repo" = "local" ]]; then
 			((DETAILUPGRADE<2)) && echo -en "$prefix$(gettext 'Foreign packages: ')${bar:$((++i%4)):1} $i / $1"

--- a/src/lib/abs.sh.in
+++ b/src/lib/abs.sh.in
@@ -122,6 +122,7 @@ classify_pkg() {
 	unset srcpkgs pkgs
 	longestpkg=(0 0)
 	local i=0 bar="|/-\\"
+	local pkg_nb=$1
 	local pkgname repo rversion lversion outofdate pkgdesc maintainer \
 	      pkgver lrel rrel lver rver
 	local prefix=''
@@ -130,12 +131,13 @@ classify_pkg() {
 	fi
 	while read pkgname repo rversion lversion outofdate maintainer pkgdesc; do
 		if [[ "${IGNORED_PACKAGES[@]}" =~ "$repo/$pkgname" ]]; then
+			pkg_nb=$(($pkg_nb - 1))
 			continue;
 		fi
 		
 		printf -v pkgdesc "%q" "$pkgdesc"
 		if [[ "$repo" = "aur" && ${lversion#-} ]] || [[ "$repo" = "local" ]]; then
-			((DETAILUPGRADE<2)) && echo -en "$prefix$(gettext 'Foreign packages: ')${bar:$((++i%4)):1} $i / $1"
+			((DETAILUPGRADE<2)) && echo -en "$prefix$(gettext 'Foreign packages: ')${bar:$((++i%4)):1} $i / $pkg_nb"
 			[[ "$repo" = "local" ]] && continue
 			aur_update_exists "$pkgname" "$rversion" "$lversion" "$outofdate" "$maintainer" \
 				|| continue

--- a/src/yaourtrc.in
+++ b/src/yaourtrc.in
@@ -24,6 +24,7 @@
 # If the package "abs" is installed, those var are parsed from abs.conf
 #REPOS=()           # REPOS available at $SYNCSERVER
 #SYNCSERVER=""
+#IGNORED_PACKAGES=() #A list of ignored packages. E.g. ("aur/btsync" "aur/dropbox")
 
 # AUR
 #AURURL="@aururl@"


### PR DESCRIPTION
Hi, 

I needed a way to ignore some packages from showing up in the upgrade list. 

My solution: 
- Define a list of ignored packages in your ```/etc/yaourtrc```. 
- In ```classify_pkg()``` skip the ignored packages.

Some people told me that this may be useful to them, so I'd like to share this with you. 

Feedback welcomed :)

Kind regards,
gehaxelt