### PR TITLE
Remove "-e" from "read -ea packagesnum"

### DIFF
--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -228,7 +228,7 @@ yaourt_interactive() {
 	SEARCH=1 search 1
 	[[ $PKGSFOUND ]] || die 0
 	prompt $(gettext 'Enter n° of packages to be installed (ex: 1 2 3 or 1-3)')
-	read -ea packagesnum
+	read -a packagesnum
 	[[ $packagesnum ]] || die 0
 	for line in ${packagesnum[@]/,/ }; do
 		(( line )) || die 1	# not a number, range neither


### PR DESCRIPTION
When we use `read -e`, type something, then press some backspaces, the whole line is empty, including "==> ". And using readline seems unnecessary here.

```
==> Enter n° of packages to be installed (ex: 1 2 3 or 1-3)
==> -------------------------------------------------------
==> _
```

```
==> Enter n° of packages to be installed (ex: 1 2 3 or 1-3)
==> -------------------------------------------------------
==> 1_(a backspace)
```
```
==> Enter n° of packages to be installed (ex: 1 2 3 or 1-3)
==> -------------------------------------------------------
_
```
