### PR TITLE
fix: makepkg: no changes detected

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -18,7 +18,7 @@ backup=('etc/yaourtrc')
 source=()
 
 build() { 
-	cp -r ../../src/ "$srcdir/yaourt/"
+	cp -r ../../src/. "$srcdir/yaourt/"
 	cd "$srcdir/yaourt/"
 	make PREFIX=/usr sysconfdir=/etc localstatedir=/var 
 }


### PR DESCRIPTION
- the first run of makepkg moved the src dir to $srcdir and renamed it to yaourt
- the second+ run of makegpkg copied the src dir in $srcdir/yaourt

=> no files were replaced, no changes detected