### PR TITLE
Add package-query's --nameonly option

### DIFF
--- a/src/man/yaourt.8
+++ b/src/man/yaourt.8
@@ -186,6 +186,11 @@ Filter output to packages installed as dependencies\&.
 Filter output to packages not required by any currently installed package\&. With
 \fI\-d\fR, yaourt list all real orphans and ask for deletion\&.
 .RE
+.PP
+\fB\-d, \-\-nameonly\fR
+.RS 4
+Query the package names only (names and descriptions are queried by default)\&.
+.RE
 .SH "SYNC OPTIONS"
 .PP
 \fB\-a, \-\-aur\fR

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -353,6 +353,7 @@ while [[ $1 ]]; do
 		--sort)             SORT=$2; shift;;
 		--stats)            MAJOR="stats";;
 		--tmp)              shift; TMPDIR="$1";;
+		--nameonly)         program_arg $A_PQ $1;;
 		-V|--version)       version; exit 0;;
 		-v)                 program_arg $((A_PQ | A_PS)) $1;;
 		-q|--quiet)         QUIET=1; DETAILUPGRADE=0; program_arg $((A_PS | A_PQ)) $1;;


### PR DESCRIPTION
This is for the issue #73 
The option is already supported by package-query, now adding it to yaourt.

With this option, the package names will only be searched. Regexes can be used when querying the local DBs; AUR only supports plain text search.