### PR TITLE
Allow cloning into existing directory.

### DIFF
--- a/src/lib/aur.sh
+++ b/src/lib/aur.sh
@@ -24,7 +24,10 @@ aur_get_pkgbuild() {
 	if ((local_aurusegit)); then
 		local git_repo_url=$(pkgquery -Aif "%G" "$pkg")
 		# We're already in "$pkg"/ here, so clone to the current directory
-		git clone "$git_repo_url" . || return 1
+		git init
+		git remote add origin "$git_repo_url" || git remote set-url origin "$git_repo_url"
+		git fetch || return 1
+		git checkout -t origin/master || git checkout master
 	else
 		[[ -z "$pkgurl" ]] && pkgurl=$(pkgquery -Aif "%u" "$pkg")
 		if [[ ! "$pkgurl" ]] || ! curl_fetch -fs "$pkgurl" -o "$pkg.tar.gz"; then


### PR DESCRIPTION
Fixes #162. Another option would be to `rm –rf .`. The advantage with doing it this way is that all the Git objects should still be recoverable even if you do `[R]eplace` by mistake. This is the least destructive approach I can think of, but I'd definitely be happy to hear any suggestions.

```
~/tmp > yaourt -G cryptsetup-git
==> cryptsetup-git directory already exist. [R]eplace, [C]hange to ./cryptsetup-git.oHr, [S]kip ? R
==> Download cryptsetup-git sources
Reinitialized existing Git repository in /home/dave/tmp/cryptsetup-git/.git/
fatal: remote origin already exists.
fatal: A branch named 'master' already exists.
Already on 'master'
Your branch is up-to-date with 'origin/master'.
```

And of course, it doesn't change cloning a nonexistent directory.

```
~/tmp > yaourt -G binwalk
==> Download binwalk sources
Initialized empty Git repository in /home/dave/tmp/binwalk/.git/
remote: Counting objects: 5, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 5 (delta 0), reused 5 (delta 0)
Unpacking objects: 100% (5/5), done.
From ssh://aur.archlinux.org/binwalk
 * [new branch]      master     -> origin/master
Branch master set up to track remote branch master from origin.
Already on 'master'
```
