### PR TITLE
yaourt -C: forward the environment variable DIFFEDITCMD to pacdiffviewer

### DIFF
--- a/src/lib/util.sh.in
+++ b/src/lib/util.sh.in
@@ -249,7 +249,7 @@ DETAILUPGRADE=1
 SHOWORPHANS=1
 TERMINALTITLE=1
 # Command
-DIFFEDITCMD="vimdiff"
+DIFFEDITCMD=${DIFFEDITCMD:-vimdiff}
 
 source_config() {
 	local env_EDITOR="$EDITOR"

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -397,7 +397,7 @@ fi
 case "$MAJOR" in
 	clean)
 		(( CLEAN )) && _arg="-c" || _arg=""
-		launch_with_su pacdiffviewer $_arg
+		launch_with_su bash -c "DIFFEDITCMD=\"$DIFFEDITCMD\" pacdiffviewer $_arg"
 		;;
 
 	stats)


### PR DESCRIPTION
There might be a better way to fix this, but I didn't get to it.

Fix #127