### PR TITLE
ADD FEATURE: Handle local PKGBUILD and its dependencies

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -35,6 +35,10 @@ Manage .pac* files.
 
 Get PKGBUILD for ABS or AUR.
 
+=item B<-P, --pkgbuild E<lt>directoryE<gt>>
+
+Build package from PKGBUILD found in a local directory. Also install the packacke with I<-i>.
+
 =item B<-Q, --query>
 
 Query local database + Can sort packages by installation date, possibility to delete orphans.

--- a/src/bashcompletion
+++ b/src/bashcompletion
@@ -24,11 +24,11 @@ _yaourt ()
       _pacman_file; return 0;
     else
       _pacman &> /dev/null
-      _arch_compgen "${COMPREPLY[@]}" "-B --backup -C -G --getpkgbuild --stats"
+      _arch_compgen "${COMPREPLY[@]}" "-B --backup -C -G --getpkgbuild -P --pkgbuild --stats"
       return 0
     fi
   fi
-  for o in 'D database' 'Q query' 'R remove' 'S sync' 'U upgrade' 'B backup' 'C' 'G getpkgbuild'; do
+  for o in 'D database' 'Q query' 'R remove' 'S sync' 'U upgrade' 'B backup' 'C' 'G getpkgbuild' 'P pkgbuild'; do
     _arch_incomp "$o" && break
   done
   (($?)) && op="" || op="${o% *}"
@@ -38,6 +38,7 @@ _yaourt ()
       C) _arch_compgen "-c --clean";;
       Q) _arch_compgen  "${COMPREPLY[@]}" "--backupfile --date";;
       S) _arch_compgen  "${COMPREPLY[@]}" "-b --build -a --aur --devel --holdver";;
+      P) _arch_compgen  "${COMPREPLY[@]}" "-i --install";;
     esac
   else
     case "$op" in

--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -382,7 +382,11 @@ package_loop() {
 			*) return 99 ;; # should never execute
 		esac
 	done
-	(( ! ret )) && (( ! failed )) && { install_package || failed=1; }
+	(( ! ret )) && (( ! failed )) &&
+	  ( [[ $MAJOR == "pkgbuild" ]] && (( YPKGBUILD_INSTALL )) || ! [[ $MAJOR == "pkgbuild" ]] ) &&
+	    { install_package || failed=1; }
+
+	[[ $MAJOR == "pkgbuild" ]] && (( ! YPKGBUILD_INSTALL )) && cp -v "$YPKGDEST/"*.pkg.* $YPKGBUILDDIR
 	rm -r "$YPKGDEST"
 	return $failed
 }
@@ -459,6 +463,38 @@ get_pkgbuild() {
 		fi
 	done
 	cd "$cwd"
+}
+
+
+# Call package_pkgbuild_only for building a PKGBUILD in the current directory until success or abort
+# on success, call install_package, if YPKGBUILD_INSTALL was specified with -i
+# Usage: package_pkgbuild_only ($pkgname)
+#   $pkgname: name of package
+package_pkgbuild_only() {
+	local YTMPDIR="$YAOURTTMPDIR/aur-$pkgname"
+	local YPKG=$1
+	(( trust )) && default_answer=2
+
+	init_build_dir "$YTMPDIR" || return 1
+
+	# Glob files from YPKGBUILDDIR and copy them to $YTMPDIR
+	local YFILES="$YPKGBUILDDIR/PKGBUILD"
+	local add_files="$(find "$YPKGBUILDDIR/"*.install -type f 2>>/dev/null)"
+	[[ $? ]] && YFILES+=" $add_files"
+	unset add_files
+	local add_files="$(find "$YPKGBUILDDIR/"*.patch -type f 2>>/dev/null)"
+	[[ $? ]] && YFILES+=" $add_files"
+
+	msg $(_gettext "Copying files from %s to build directory..." "$YPKGBUILDDIR")
+	cp -v ${YFILES[@]} "$YTMPDIR"
+	echo
+
+	package_loop "$YPKG" 1 || manage_error "$YPKG" ||
+	  { cd "$cwd"; return 1; }
+	cd "$cwd"
+	rm -rf "$YTMPDIR"
+
+	return 0
 }
 
 # If we have to deal with PKGBUILD and makepkg, source makepkg conf(s)

--- a/src/man/yaourt.8
+++ b/src/man/yaourt.8
@@ -60,6 +60,11 @@ Clean Options\&.
 Get PKGBUILD for ABS or AUR\&.
 .RE
 .PP
+\fB\-P, \-\-pkgbuild <directory>\fR
+.RS 4
+Build package from PKGBUILD found in a local directory.\&.
+.RE
+.PP
 \fB\-Q, \-\-query\fR
 .RS 4
 Query local database + Can sort packages by installation date, possibility to delete orphans\&. See
@@ -163,6 +168,14 @@ Manage \&.pacnew, \&.pacsave and \&.pacorig files\&.
 \fB\-c, \-\-clean\fR
 .RS 4
 Clean all these files\&.
+.RE
+.SH "PKGBUILD OPTIONS"
+.sp
+Build package from PKGBUILD found in a local directory.\&.
+.PP
+\fB\-i, \-\-install\fR
+.RS 4
+Also install the package\&.
 .RE
 .SH "QUERY OPTIONS"
 .PP

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -50,6 +50,7 @@ usage() {
 	echo -e "\t$(gettext 'yaourt {-C --clean}       [options]')"
 	echo -e "\t$(gettext 'yaourt {-B --backup}      [save directory|restore file]')"
 	echo -e "\t$(gettext 'yaourt {-G --getpkgbuild} [options] <package(s)>')"
+	echo -e "\t$(gettext 'yaourt {-P --pkgbuild} [-i --install] <directory>')"
 	echo -e "\t$(gettext 'yaourt {--stats}')"
 }
 
@@ -222,6 +223,27 @@ yaourt_query() {
 	fi
 }
 
+# Handle building from local PKGBUILD
+yaourt_pkgbuild() {
+	! [ -d "$YPKGBUILDDIR" ] && {
+		msg $(gettext 'You have to provide a valid directory after --pkgbuild')
+		return 1
+	}
+	! [ -e "$YPKGBUILDDIR"/PKGBUILD ] && {
+		msg $(gettext 'Your directory after --pkgbuild does not contain a PKGBUILD')
+		return 1
+	}
+
+	source "$YPKGBUILDDIR/PKGBUILD"
+	local pkg="$pkgname $pkgver"
+	msg $(_gettext 'Installing %s from local PKGBUILD' "$pkg")
+
+	cd "$YPKGBUILDDIR"
+	YPKGBUILDDIR="$(pwd)"
+	package_pkgbuild_only "$pkgname"
+	return $?
+}
+
 # Handle interactive search
 yaourt_interactive() {
 	local line packages
@@ -348,6 +370,10 @@ while [[ $1 ]]; do
 		--file)             FILE=1; program_arg $A_PQ $1;;
 		--print-format)     ((PRINT++));; # --print-format needs --print
 		--pkg)              program_arg $((A_M)) $1 "$2"; SPLITOPT=1; shift;;
+		-P|--pkgbuild)		MAJOR="pkgbuild"; shift; YPKGBUILDDIR="$1"
+							if [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
+								YPKGBUILD_INSTALL=1; YPKGBUILDDIR="$2"
+							fi;;
 		-s|--search)        SEARCH=1; program_arg $A_PQ $1;;
 		--rsort)            RSORT=$2; shift;;
 		--sort)             SORT=$2; shift;;
@@ -417,6 +443,10 @@ case "$MAJOR" in
 		yaourt_backup "${ARGS[0]}"
 		;;
 
+	pkgbuild)
+		load_lib pkgbuild util misc
+		yaourt_pkgbuild
+		;;
 	upgrade) yaourt_upgrade ;;
 	sync) yaourt_sync ;;
 	query) yaourt_query ;;

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -50,7 +50,7 @@ usage() {
 	echo -e "\t$(gettext 'yaourt {-C --clean}       [options]')"
 	echo -e "\t$(gettext 'yaourt {-B --backup}      [save directory|restore file]')"
 	echo -e "\t$(gettext 'yaourt {-G --getpkgbuild} [options] <package(s)>')"
-	echo -e "\t$(gettext 'yaourt {-P --pkgbuild} [-i --install] <directory>')"
+	echo -e "\t$(gettext 'yaourt {-P --pkgbuild}    [-i --install] <directory>')"
 	echo -e "\t$(gettext 'yaourt {--stats}')"
 }
 
@@ -370,10 +370,10 @@ while [[ $1 ]]; do
 		--file)             FILE=1; program_arg $A_PQ $1;;
 		--print-format)     ((PRINT++));; # --print-format needs --print
 		--pkg)              program_arg $((A_M)) $1 "$2"; SPLITOPT=1; shift;;
-		-P|--pkgbuild)		MAJOR="pkgbuild"; shift; YPKGBUILDDIR="$1"
-							if [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
-								YPKGBUILD_INSTALL=1; YPKGBUILDDIR="$2"
-							fi;;
+		-P|--pkgbuild)      MAJOR="pkgbuild"; shift; YPKGBUILDDIR="$1"
+		                    if [[ $1 == "-i" ]] || [[ $1 == "--install" ]]; then
+		                        YPKGBUILD_INSTALL=1; YPKGBUILDDIR="$2"
+		                    fi;;
 		-s|--search)        SEARCH=1; program_arg $A_PQ $1;;
 		--rsort)            RSORT=$2; shift;;
 		--sort)             SORT=$2; shift;;


### PR DESCRIPTION
Implementation of #174 .

It is usable with `-P` (for `--pkgbuild`) and a relative path.
Man pages, Readme and bash completion are extended.

Additionally to #174 I implemented a `-i` (for `--install`) option to install the package directly, if building did not fail.