### PR TITLE
Fix handling package version with epoch

### DIFF
--- a/src/lib/aur.sh
+++ b/src/lib/aur.sh
@@ -54,7 +54,7 @@ info_from_aur() {
 	pkgbuild_url="${pkgbuild_url%/snapshot/*}/plain/PKGBUILD?h=$pkgbase"
 	curl_fetch -fis "$pkgbuild_url" -o "$tmpfile" || \
 		{ error $(_gettext '%s not found in AUR.' "$pkgname"); return 1; }
-	local vars=(pkgname pkgver pkgrel url license groups provides depends optdepends \
+	local vars=(pkgname epoch pkgver pkgrel url license groups provides depends optdepends \
 		depends_${CARCH} optdepends_${CARCH} \
 		conflicts replaces arch pkgdesc)
 	unset ${vars[*]}
@@ -67,7 +67,7 @@ info_from_aur() {
 
 	aur_show_info "Repository     " "${C[aur]:-${C[other]}}aur$C0"
 	aur_show_info "Name           " "$CBOLD$pkgname$C0"
-	aur_show_info "Version        " "$CGREEN$pkgver-$pkgrel$C0"
+	aur_show_info "Version        " "$CGREEN$(get_package_version "$epoch" "$pkgver" "$pkgrel")$C0"
 	aur_show_info "URL            " "$CCYAN$url$C0"
 	aur_show_info "AUR URL        " "$CCYAN${AURURL}/packages/$pkgname$C0"
 	aur_show_info "Licenses       " "${license[*]}"

--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -42,7 +42,7 @@ source_makepkg_conf() {
 # Set PKGBUILD_VARS, exec "eval $PKGBUILD_VARS" to have PKGBUILD content.
 read_pkgbuild() {
 	local update=${1:-0}
-	local vars=(pkgbase pkgname pkgver pkgrel arch pkgdesc provides url \
+	local vars=(pkgbase pkgname epoch pkgver pkgrel arch pkgdesc provides url \
 		groups license source install md5sums depends checkdepends makedepends conflicts \
 		depends_${CARCH} checkdepends_${CARCH} makedepends_${CARCH} \
 		replaces \
@@ -243,7 +243,7 @@ build_package() {
 				read_pkgbuild || return 1
 				eval $PKGBUILD_VARS
 			fi
-			if ! is_x_gt_y "$pkgver-$pkgrel" $(pkgversion $pkgbase); then
+			if ! is_x_gt_y $(get_package_version "$epoch" "$pkgver" "$pkgrel") $(pkgversion $pkgbase); then
 				msg $(_gettext '%s is already up to date.' "$pkgbase")
 				return 2
 			fi
@@ -283,6 +283,19 @@ build_package() {
 	fi
 	(( EXPORT && EXPORTSRC )) && [[ $SRCPKGDEST ]] && SRCDEST="$YSRCDEST" y_makepkg --allsource -p ./PKGBUILD
 	return 0
+}
+
+# Get package version
+# Usage:	get_package_version ($epoch, $pkgver, $pkgrel)
+get_package_version() {
+	local epoch=$1
+	local pkgver=$2
+	local pkgrel=$3
+	if (( epoch > 0 )); then
+		echo "$epoch:$pkgver-$pkgrel"
+	else
+		echo "$pkgver-$pkgrel"
+	fi
 }
 
 # Install package after build


### PR DESCRIPTION
Updating packages from git repository is not working when a package has epoch property in PKGBUILD.

Example:

My version of fish-git:

```
$ pacman -Q fish-git

fish-git 2:2.2.0.r436.gef67fc7-1
``` 

Current version of fish:

```
$ git describe --long | sed -r 's/([^-]*-g)/r\1/;s/-/./g' (executed in fish repository)

2.2.0.r456.g8104854-1
```

So it should be updated.

When I'm trying to update packages:

```
$ yaourt -Su --devel

...
==> Building and installing package
==> Making package: fish-git 2:2.2.0.r278.ge70ed96-1 (Sat Dec 12 11:45:36 CET 2015)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Cloning fish-shell git repo...
Cloning into bare repository '/tmp/yaourt-tmp-bartekmanj/aur-fish-git/fish-shell'...
remote: Counting objects: 37095, done.
remote: Compressing objects: 100% (249/249), done.
remote: Total 37095 (delta 134), reused 0 (delta 0), pack-reused 36846
Receiving objects: 100% (37095/37095), 30.72 MiB | 139.00 KiB/s, done.
Resolving deltas: 100% (22509/22509), done.
Checking connectivity... done.
==> Validating source files with md5sums...
    fish-shell ... Skipped
==> Extracting sources...
  -> Creating working copy of fish-shell git repo...
Cloning into 'fish-shell'...
done.
==> Starting pkgver()...
==> Updated version: fish-git 2:2.2.0.r456.g8104854-1
==> Sources are ready.
==> fish-git is already up to date.
...
```

Aborting an update is caused by comparing versions with and without epoch [here](https://github.com/archlinuxfr/yaourt/blob/master/src/lib/pkgbuild.sh.in#L246):

```
$ vercmp 2.2.0.r456.g8104854-1 2:2.2.0.r436.gef67fc7-1

-1
```

To fix that I added handling of epoch.