### PR TITLE
Use delimiter option instead of deprecated csep

### DIFF
--- a/src/pacdiffviewer.sh.in
+++ b/src/pacdiffviewer.sh.in
@@ -52,7 +52,7 @@ usage() {
 # Save files marked as backup in packages for a possible later merge
 backup_files() {
 	local _file _md5sum _version pkgname pkgver backupdir currentfile
-	pkgquery -Qf '%n - %v\n%B' --csep '\n' |
+	pkgquery -Qf '%n - %v\n%B' --delimiter '\n' |
 	while read _file _md5sum _version
 	do
 		# no backups


### PR DESCRIPTION
The --csep option has been declared deprecated long ago. Replacing it with --delimiter will allow to remove it from the ```package-query``` code.

```
commit 82f02bbc7ba15dff9629dedce1054c21eb3dbc04
Author: tuxce <tuxce.net@gmail.com>
Date:   Thu Sep 8 12:37:28 2011 +0200

    Update --help output.
    
    Option change: --delimiter instead of --csep
    (--csep still exists but will be removed later)
```