### PR TITLE
add a --confirm option

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -97,6 +97,10 @@ Disable color.
 
 Don't ask for confirmation.
 
+=item B<--confirm>
+
+Always ask for confirmation, even when the configuration says otherwise.
+
 =item B<--pager>
 
 Use I<$PAGER> to show search results.

--- a/src/man/yaourt.8
+++ b/src/man/yaourt.8
@@ -133,6 +133,11 @@ Disable color\&.
 Don\(cqt ask for confirmation\&.
 .RE
 .PP
+\fB\-\-confirm\fR
+.RS 4
+Always ask for confirmation, even when the configuration says otherwise\&.
+.RE
+.PP
 \fB\-\-pager\fR
 .RS 4
 Use

--- a/src/man/yaourtrc.5
+++ b/src/man/yaourtrc.5
@@ -208,7 +208,7 @@ Specify the folder where yaourt exports built packages + sources\&.
 .PP
 \fBNOCONFIRM=0\fR
 .RS 4
-If set to 1, always use the default choice without confirmation\&.
+If set to 1, always use the default choice without confirmation, unless overwritten by --confirm\&.
 .RE
 .PP
 \fBUP_NOCONFIRM=0\fR

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -387,6 +387,7 @@ while [[ $1 ]]; do
 		--needed)           NEEDED=1; program_arg $A_PS $1;;
 		--nocolor)          USECOLOR=0;;
 		--noconfirm)        NOCONFIRM=1;;
+		--confirm)          NOCONFIRM=0;;
 		--nodeps)           program_arg $((A_PS | A_M)) $1;;
 		--noprogressbar)    program_arg $A_PC $1;;
 		--noscriptlet)      program_arg $A_PC $1;;


### PR DESCRIPTION
When `NOCONFIRM` is set to `1` in `yaourtrc` it poses useful to overwrite this directive on demand. To that end, this patch provides a `--confirm` option inverting the existing `--noconfirm`.

This should at least partly provide what #106 wished for.