### PR TITLE
Add and pass --confirm option to pacdiffviewer

### DIFF
--- a/src/pacdiffviewer.sh.in
+++ b/src/pacdiffviewer.sh.in
@@ -259,6 +259,7 @@ while [[ $1 ]]; do
 		-s) SEQUENTIAL=1;;
 		-d) DIFF=1;;
 		--backup|-b) action=backup;;
+		--confirm) NOCONFIRM=0;;
 		-c)	action=clean;;
 		-*) usage $1;;
 	esac

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -466,6 +466,7 @@ case "$MAJOR" in
 	# yaourt -C
 	clean)
 		(( CLEAN )) && _arg="-c" || _arg=""
+		(( NOCONFIRM )) || _arg+=" --confirm"
 		launch_with_su bash -c "DIFFEDITCMD=\"$DIFFEDITCMD\" pacdiffviewer $_arg"
 		;;
 


### PR DESCRIPTION
In a follow up to #235, I herewith propose the `--confirm` option to *pacdiffviewer*, too. Without a way to overwrite a set `NOCONFIRM`, `yaourt -C` will never do anything.