### PR TITLE
Add a --edit option

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -101,6 +101,10 @@ Don't ask for confirmation.
 
 Always ask for confirmation, even when the configuration says otherwise.
 
+=item B<--edit>
+
+Always edit files, even when the configuration says otherwise.
+
 =item B<--pager>
 
 Use I<$PAGER> to show search results.

--- a/src/man/yaourt.8
+++ b/src/man/yaourt.8
@@ -138,6 +138,10 @@ Don\(cqt ask for confirmation\&.
 Always ask for confirmation, even when the configuration says otherwise\&.
 .RE
 .PP
+\fB\-\-edit\fR
+.RS 4
+Always edit files, even when the configuration says otherwise\&.
+.RE
 \fB\-\-pager\fR
 .RS 4
 Use

--- a/src/man/yaourt.8
+++ b/src/man/yaourt.8
@@ -142,6 +142,7 @@ Always ask for confirmation, even when the configuration says otherwise\&.
 .RS 4
 Always edit files, even when the configuration says otherwise\&.
 .RE
+.PP
 \fB\-\-pager\fR
 .RS 4
 Use

--- a/src/man/yaourtrc.5
+++ b/src/man/yaourtrc.5
@@ -223,7 +223,7 @@ If set to 1, do not prompt while building\&.
 .PP
 \fBEDITFILES=1\fR
 .RS 4
-If set to 0, don\(cqt propose to edit files (from AUR or from ABS)\&.
+If set to 0, don\(cqt propose to edit files (from AUR or from ABS), unless overwritten by --edit\&.
 .RE
 .PP
 \fBNOENTER=1\fR

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -384,7 +384,7 @@ while [[ $1 ]]; do
 		--nocolor)          USECOLOR=0;;
 		--noconfirm)        NOCONFIRM=1;;
 		--confirm)          NOCONFIRM=0;;
-		--edit)				EDITFILES=1;;
+		--edit)             EDITFILES=1;;
 		--nodeps)           program_arg $((A_PS | A_M)) $1;;
 		--noprogressbar)    program_arg $A_PC $1;;
 		--noscriptlet)      program_arg $A_PC $1;;

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -384,6 +384,7 @@ while [[ $1 ]]; do
 		--nocolor)          USECOLOR=0;;
 		--noconfirm)        NOCONFIRM=1;;
 		--confirm)          NOCONFIRM=0;;
+		--edit)				EDITFILES=1;;
 		--nodeps)           program_arg $((A_PS | A_M)) $1;;
 		--noprogressbar)    program_arg $A_PC $1;;
 		--noscriptlet)      program_arg $A_PC $1;;


### PR DESCRIPTION
When EDITFILES is set to 0 in yaourtrc it poses useful to overwrite this directive on demand. To that end, this patch provides an --edit option.

This finishes up what #106 wished for.