### PR TITLE
Rename INSTALL to INSTALL_FLAG

### DIFF
--- a/src/lib/pkgbuild.sh.in
+++ b/src/lib/pkgbuild.sh.in
@@ -265,7 +265,7 @@ build_package() {
 	# install deps from abs (build or download) as depends
 	if [[ $PKGBUILD_DEPS ]]; then
 		msg $(_gettext 'Install or build missing dependencies for %s:' "$pkgbase")
-		if ! SP_ARG="--asdeps" INSTALL=1 sync_packages "${PKGBUILD_DEPS[@]}"; then
+		if ! SP_ARG="--asdeps" INSTALL_FLAG=1 sync_packages "${PKGBUILD_DEPS[@]}"; then
 			local _deps_left=( $(pacman_parse -T "${PKGBUILD_DEPS[@]}") )
 			local _deps_installed=()
 			for _deps in "${PKGBUILD_DEPS[@]}"; do
@@ -404,10 +404,10 @@ package_loop() {
 		esac
 	done
 	(( ! ret )) && (( ! failed )) &&
-	  ( [[ $MAJOR == "pkgbuild" ]] && (( INSTALL )) || ! [[ $MAJOR == "pkgbuild" ]] ) &&
+	  ( [[ $MAJOR == "pkgbuild" ]] && (( INSTALL_FLAG )) || ! [[ $MAJOR == "pkgbuild" ]] ) &&
 	    { install_package || failed=1; }
 
-	[[ $MAJOR == "pkgbuild" ]] && (( ! INSTALL )) && cp -v "$YPKGDEST/"*.pkg.* $YPKGBUILDDIR
+	[[ $MAJOR == "pkgbuild" ]] && (( ! INSTALL_FLAG )) && cp -v "$YPKGDEST/"*.pkg.* $YPKGBUILDDIR
 	rm -r "$YPKGDEST"
 	return $failed
 }
@@ -490,7 +490,7 @@ get_pkgbuild() {
 
 
 # Call package_pkgbuild_only for building a PKGBUILD in the current directory
-# until success or abort. On success, call install_package, if INSTALL was
+# until success or abort. On success, call install_package, if INSTALL_FLAG was
 # specified with -i
 # Usage: package_pkgbuild_only ($pkgname)
 #   $pkgname: name of package

--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -345,7 +345,7 @@ while [[ $1 ]]; do
 		-e|--explicit)      program_arg $A_PQ $1;;
 		-g|--groups)        GROUP=1; program_arg $A_PQ $1;;
 		-h|--help)          usage; exit 0;;
-		-i)                 [[ $MAJOR = "pkgbuild" ]] && INSTALL=1 || { INFO=1; program_arg $((A_PQ | A_PS)) $1; };;
+		-i)                 [[ $MAJOR = "pkgbuild" ]] && INSTALL_FLAG=1 || { INFO=1; program_arg $((A_PQ | A_PS)) $1; };;
 		-k|--check)         [[ ! $PACMAN_CMD ]] && PACMAN_CMD=0;;
 		-l|--list)          LIST=1; program_arg $A_PQ $1;;
 		-m|--foreign)       FOREIGN=1; program_arg $A_PQ $1;;
@@ -409,7 +409,7 @@ while [[ $1 ]]; do
 		--devel)            DEVEL=1;;
 		--export)           EXPORT=1; EXPORTSRC=1; shift; EXPORTDIR="$1";;
 		--insecure)         program_arg $((A_PKC | A_CC)) $1;;
-		--install)          INSTALL=1;;
+		--install)          INSTALL_FLAG=1;;
 		--m-arg)            program_arg $A_M "$2"; shift;;
 		--maintainer)       program_arg $A_PQ $1;;
 		--nameonly)         program_arg $A_PQ $1;;


### PR DESCRIPTION
Autoconf tries to get a BSD `install` command and use `INSTALL` variable to
store the result. So if `INSTALL` is set to something by yaourt, it will
make autoconf set install command pointing to this and end up in an error
during the package.

In order to avoid collision between `-i` option of major `-P` (pkgbuild)
with this `INSTALL` variable of autoconf, rename `-i` flag to `INSTALL_FLAG`.