### PR TITLE
Change "ex" to "e.g."

### DIFF
--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -256,7 +256,7 @@ yaourt_interactive() {
 	local line packages
 	SEARCH=1 search 1
 	[[ $PKGSFOUND ]] || die 0
-	prompt $(gettext 'Enter n° of packages to be installed (ex: 1 2 3 or 1-3)')
+	prompt $(gettext 'Enter n° of packages to be installed (e.g., 1 2 3 or 1-3)')
 	read -a packagesnum
 	[[ $packagesnum ]] || die 0
 	for line in ${packagesnum[@]/,/ }; do


### PR DESCRIPTION
Which is a common way to say "for example".
Fixes #312