### PR TITLE
Make --noconfirm say 'Y' to removing conflicted packages

### DIFF
--- a/src/yaourt.sh.in
+++ b/src/yaourt.sh.in
@@ -449,8 +449,10 @@ if (( NOCONFIRM )); then
 	EDITFILES=0
 	BUILD_NOCONFIRM=1
 	AURVOTE=0
+	program_arg $A_PS "--ask" "36"
 	program_arg $((A_PS | A_M)) "--noconfirm"
 elif ((SYSUPGRADE && UP_NOCONFIRM)) || ((PU_NOCONFIRM)); then
+	program_arg $A_PU "--ask" "36"
 	program_arg $A_PU "--noconfirm"
 fi
 ((FORCE)) && program_arg $((A_PS | A_M)) "--force"


### PR DESCRIPTION
I found this little gem in `pacaur` code and I think it totally makes sense to have in `yaourt`.

Today when using `--noconfirm`, the installation gets aborted on conflict, because `N` is a default option:

```
:: dunst and dunst-git are in conflict. Remove dunst? [y/N]
error: unresolvable package conflicts detected
error: failed to prepare transaction (conflicting dependencies)
:: dunst and dunst-git are in conflict
```

However, as the author of pacaur [explained on reddit](https://www.reddit.com/r/archlinux/comments/5m58ht/pacman_automatically_say_yes_to_conflict_messages/dc10qfr/), by providing an undocumented parameter `--ask 36` to pacman, the default changes to `Y`.

It makes so much more sense! And it's already in the sources of pacaur. Let's have it as well 🙂