### PR TITLE
Add AURTRUST option to yaourtrc, not to edit PKGBUILDs as default answer

### DIFF
--- a/src/lib/aur.sh
+++ b/src/lib/aur.sh
@@ -189,6 +189,7 @@ vote_package() {
 # give to user all info to build and install Unsupported package from AUR
 install_from_aur() {
 	local cwd
+	local trust=$AURTRUST
 	declare -a pkginfo=($(pkgquery -1Aif "%n %i %v %w %o %u %m %l %L" "$1"))
 	[[ "${pkginfo[1]#-}" ]] || return 1
 	in_array ${pkginfo[0]} "${AUR_INSTALLED_PKGS[@]}" && return 0
@@ -206,7 +207,7 @@ install_from_aur() {
 	echo -e "$CBLINK$CRED$(gettext '( Unsupported package: Potentially dangerous ! )')$C0"
 
 	# Build, install/export
-	package_loop ${pkginfo[0]} 0 || manage_error ${pkginfo[0]} ||
+	package_loop ${pkginfo[0]} $trust || manage_error ${pkginfo[0]} ||
 	  { cd "$cwd"; return 1; }
 	cd "$cwd"
 	rm -rf "$YAOURTTMPDIR/aur-${pkginfo[0]}"

--- a/src/man/yaourtrc.5
+++ b/src/man/yaourtrc.5
@@ -183,6 +183,11 @@ If set to 0, don\(cqt check the vote status for inclusion/keeping in [community]
 .RS 4
 If set to 1, clone the AUR git repository instead of using snapshot tarballs.
 .RE
+.PP
+\fBAURTRUST=0\fR
+.RS 4
+If set to 1, the default answer for the prompt to edit PKGBUILDs and .install files is set to N.
+.RE
 .SH "BUILD OPTIONS"
 .PP
 \fBEXPORT=0\fR

--- a/src/yaourtrc.in
+++ b/src/yaourtrc.in
@@ -29,6 +29,7 @@
 #AURUPGRADE=0
 #AURVOTE=1
 #AURUSEGIT=0
+#AURTRUST=0
 
 # Build
 #EXPORT=0           # Export to 1: EXPORTDIR or PKGDEST


### PR DESCRIPTION
Implement #297 as opt-in by adding an option in yaourtrc.
So you still have the option to edit PKGBUILDs (not like EDITFILES=0), but can press Enter instead of N.