### PR TITLE
fix misleading yes translation in zhcn

### DIFF
--- a/src/po/yaourt/zh_CN.po
+++ b/src/po/yaourt/zh_CN.po
@@ -348,7 +348,7 @@ msgstr "如果想要恢复这个备份，请输入 \"yes\""
 
 #: ../../lib/alpm_backup.sh:56
 msgid "yes"
-msgstr "是"
+msgstr "yes"
 
 #: ../../lib/alpm_backup.sh:57
 msgid "Deleting pacman DB"


### PR DESCRIPTION
When trying to restore the backup, yaourt ask:
`
如果想要恢复这个备份，请输入 \"yes\"  (If you want to restore this backup, type \"yes\")
`
I type "yes" but yaourt do nothing and quit
The problem is "yes" did not translate in prompt,  but when compare user‘s reply translate it to “是” 


